### PR TITLE
Resources combo

### DIFF
--- a/assets/components/redirector/js/mgr/combos.js
+++ b/assets/components/redirector/js/mgr/combos.js
@@ -10,14 +10,16 @@ Redi.combo.ResourceList = function(config) {
 		typeAhead: true,
 		editable: true,
 		allowBlank: true,
-		autocomplete: true,
+		minListWidth: 300,
+		listAlign: ['tr-br?', [30, 0]],
+		pageSize: 20,
 		url: Redi.config.connector_url,
 		baseParams: {
             action: 'mgr/resources/getList',
 			combo: true
         }
     });
-	
+
     Redi.combo.ResourceList.superclass.constructor.call(this, config);
 };
 


### PR DESCRIPTION
### What does it do ?
- fixes resource combo pagination for Revo 2.3+
- made combo list minimum width to 300px so pagetitle are readable without a maximized window
- aligned the combo list to the bottom right of the combo
### Why is it needed ?

Mostly for a better user experience
