### PR TITLE
Allow blank target

### DIFF
--- a/assets/components/redirector/js/mgr/widgets/redirects.grid.js
+++ b/assets/components/redirector/js/mgr/widgets/redirects.grid.js
@@ -308,7 +308,7 @@ Redi.window.CreateUpdateRedirect = function(config) {
                             ,fieldLabel: _('redirector.target')
                             ,name: 'target'
                             ,anchor: '100%'
-                            ,allowBlank: false
+                            ,allowBlank: true
                         }]
                     },{
                         layout: 'form'


### PR DESCRIPTION
### What does it do ?

Allow target to be blank.
### Why is it needed ?

The idea is that "blank" value is valid when you want to redirect to `site_start` of a context.
The current behavior is that, if FURLs are turned on, it redirects to `$site_url/$site_start_alias`, then Revo behavior is to redirect to `$site_url`.
That just prevents an extra 301 redirection
### To do next

When selecting a "site_start" resource, add an empty `modRedirect.target` instead of making use of the URI.
