### PR TITLE
Handle redirection in a different context

### DIFF
--- a/assets/components/redirector/js/mgr/widgets/redirects.grid.js
+++ b/assets/components/redirector/js/mgr/widgets/redirects.grid.js
@@ -319,13 +319,20 @@ Redi.window.CreateUpdateRedirect = function(config) {
                             xtype: 'redirector-combo-resourcelist'
                             ,fieldLabel: _('resource')
                             ,valueField: 'uri'
-                            ,fields: ['uri','pagetitle']
+                            ,fields: ['uri', 'pagetitle', 'url', 'context_key']
                             ,anchor: '100%'
                             ,listeners: {
-                                'select': {
+                                select: {
                                     fn: function(cb, e) {
+                                        var ctx = this.fp.find('name', 'context_key')[0].getValue()
+                                            ,value = cb.getValue()
+                                            ,record = cb.findRecord('uri', value);
+                                        // Handle target in a different context
+                                        if (ctx && ctx != record.get('context_key')) {
+                                            value = record.get('url');
+                                        }
                                         var targetField = Ext.getCmp('redirector-createupdate-window-target-'+this.ident);
-                                            targetField.setValue(cb.getValue());
+                                            targetField.setValue(value);
                                     } ,scope: this
                                 }
                             }

--- a/core/components/redirector/processors/mgr/resources/getlist.class.php
+++ b/core/components/redirector/processors/mgr/resources/getlist.class.php
@@ -21,6 +21,7 @@ class ResourcesGetListProcessor extends modObjectGetListProcessor {
 
     public function prepareRow(xPDOObject $object) {
         $arr = $object->toArray();
+        $arr['url'] = $this->modx->makeUrl($object->get('id'), $object->get('context_key'), '', 'full');
         $arr['pagetitle'] .= ' ('.$object->get('context_key').', '.$object->get('id').')';
 
         return $arr;


### PR DESCRIPTION
### What does it do ?

Handle redirection in another context by checking if : 
1. a context is set for the redirection
2. the defined context is different than the selected resource one
### Why is it needed ?

In a multi-context environment, redirecting to another context needs a full URL (not only an URI).
