### PR TITLE
Set index length for utf8mb4 charset

### DIFF
--- a/core/components/redirector/model/redirector/mysql/modredirect.map.inc.php
+++ b/core/components/redirector/model/redirector/mysql/modredirect.map.inc.php
@@ -4,7 +4,7 @@
  */
 $xpdo_meta_map['modRedirect']= array (
   'package' => 'redirector',
-  'version' => '1.0',
+  'version' => '1.1',
   'table' => 'redirects',
   'extends' => 'xPDOSimpleObject',
   'tableMeta' => 
@@ -81,6 +81,73 @@ $xpdo_meta_map['modRedirect']= array (
       'null' => false,
       'default' => 1,
       'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'pattern' => 
+    array (
+      'alias' => 'pattern',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'pattern' => 
+        array (
+          'length' => '191',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'target' => 
+    array (
+      'alias' => 'target',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'target' => 
+        array (
+          'length' => '191',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'context_key' => 
+    array (
+      'alias' => 'context_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'context_key' => 
+        array (
+          'length' => '191',
+          'collation' => 'A',
+          'null' => true,
+        ),
+      ),
+    ),
+    'active' => 
+    array (
+      'alias' => 'active',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'active' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
     ),
   ),
   'aggregates' => 

--- a/core/components/redirector/model/schema/redirector.mysql.schema.xml
+++ b/core/components/redirector/model/schema/redirector.mysql.schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model package="redirector" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" version="1.0">
+<model package="redirector" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" version="1.1">
     <object class="modRedirect" table="redirects" extends="xPDOSimpleObject">
         <field key="pattern" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
         <field key="target" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
@@ -8,6 +8,19 @@
 	    <field key="triggered_first" dbtype="timestamp" phptype="datetime" null="true" default="NULL" />
 	    <field key="triggered_last" dbtype="timestamp" phptype="datetime" null="true" default="NULL" />
 	    <field key="active" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="1" index="index" />
+
+        <index alias="pattern" name="pattern" primary="false" unique="false" type="BTREE">
+            <column key="pattern" length="191" collation="A" null="false" />
+        </index>
+        <index alias="target" name="target" primary="false" unique="false" type="BTREE">
+            <column key="target" length="191" collation="A" null="false" />
+        </index>
+        <index alias="context_key" name="context_key" primary="false" unique="false" type="BTREE">
+            <column key="context_key" length="191" collation="A" null="true" />
+        </index>
+        <index alias="active" name="active" primary="false" unique="false" type="BTREE">
+            <column key="active" length="" collation="A" null="false" />
+        </index>
 
         <aggregate alias="PatternResource" class="modResource" local="pattern" foreign="uri" cardinality="one" owner="foreign" />
         <aggregate alias="TargetResource" class="modResource" local="target" foreign="uri" cardinality="one" owner="foreign" />


### PR DESCRIPTION
With a utf8mb4 charset, the database table `modx_redirects` can't be created on install because of the indexes length.
Error message: "Index column size too large. The maximum column size is 767 bytes."

This PR changes the schema and explicitly sets the length of the indexes.